### PR TITLE
fix readme typo s/$iput/$input/

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Data::Validator::Recursive - recursive data friendly Data::Validator
     };
 
     # do validation
-    my $params = $rule->validate($iput) or croak $rule->error->{message};
+    my $params = $rule->validate($input) or croak $rule->error->{message};
 
 # DESCRIPTION
 


### PR DESCRIPTION
Hi Xaicron,

Im testing your Data::Validator::Recursive and found a typo in the readme that made copy/paste test fail :p 

This small contribution should fix that =)